### PR TITLE
Replacing Qualys with native ssl/tls scanning

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -19,10 +19,11 @@ markdown2 = "*"
 validators = "*"
 pyjwt = "*"
 tldextract = "*"
+sslyze = "*"
 
 [requires]
 python_version = "3.8"
 
 [scripts]
-test = "pipenv run pytest -s --cov --cov-config=.coveragerc"
+test = "pipenv run pytest -s --cov --cov-config=.coveragerc --disable-warnings"
 lint = "pipenv run flake8 . --config=.flake8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "8f324173f0c34eb4c05e3eb34fa43f1c11c75c087eb0ddf221914aea0efe8323"
+            "sha256": "0e89bbb706f74df5dcb36c31cb511782df3bcb4ddb56ec9e05d97b319a9aa74b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,12 +23,78 @@
             ],
             "version": "==2020.11.8"
         },
+        "cffi": {
+            "hashes": [
+                "sha256:005f2bfe11b6745d726dbb07ace4d53f057de66e336ff92d61b8c7e9c8f4777d",
+                "sha256:09e96138280241bd355cd585148dec04dbbedb4f46128f340d696eaafc82dd7b",
+                "sha256:0b1ad452cc824665ddc682400b62c9e4f5b64736a2ba99110712fdee5f2505c4",
+                "sha256:0ef488305fdce2580c8b2708f22d7785ae222d9825d3094ab073e22e93dfe51f",
+                "sha256:15f351bed09897fbda218e4db5a3d5c06328862f6198d4fb385f3e14e19decb3",
+                "sha256:22399ff4870fb4c7ef19fff6eeb20a8bbf15571913c181c78cb361024d574579",
+                "sha256:23e5d2040367322824605bc29ae8ee9175200b92cb5483ac7d466927a9b3d537",
+                "sha256:2791f68edc5749024b4722500e86303a10d342527e1e3bcac47f35fbd25b764e",
+                "sha256:2f9674623ca39c9ebe38afa3da402e9326c245f0f5ceff0623dccdac15023e05",
+                "sha256:3363e77a6176afb8823b6e06db78c46dbc4c7813b00a41300a4873b6ba63b171",
+                "sha256:33c6cdc071ba5cd6d96769c8969a0531be2d08c2628a0143a10a7dcffa9719ca",
+                "sha256:3b8eaf915ddc0709779889c472e553f0d3e8b7bdf62dab764c8921b09bf94522",
+                "sha256:3cb3e1b9ec43256c4e0f8d2837267a70b0e1ca8c4f456685508ae6106b1f504c",
+                "sha256:3eeeb0405fd145e714f7633a5173318bd88d8bbfc3dd0a5751f8c4f70ae629bc",
+                "sha256:44f60519595eaca110f248e5017363d751b12782a6f2bd6a7041cba275215f5d",
+                "sha256:4d7c26bfc1ea9f92084a1d75e11999e97b62d63128bcc90c3624d07813c52808",
+                "sha256:529c4ed2e10437c205f38f3691a68be66c39197d01062618c55f74294a4a4828",
+                "sha256:6642f15ad963b5092d65aed022d033c77763515fdc07095208f15d3563003869",
+                "sha256:85ba797e1de5b48aa5a8427b6ba62cf69607c18c5d4eb747604b7302f1ec382d",
+                "sha256:8f0f1e499e4000c4c347a124fa6a27d37608ced4fe9f7d45070563b7c4c370c9",
+                "sha256:a624fae282e81ad2e4871bdb767e2c914d0539708c0f078b5b355258293c98b0",
+                "sha256:b0358e6fefc74a16f745afa366acc89f979040e0cbc4eec55ab26ad1f6a9bfbc",
+                "sha256:bbd2f4dfee1079f76943767fce837ade3087b578aeb9f69aec7857d5bf25db15",
+                "sha256:bf39a9e19ce7298f1bd6a9758fa99707e9e5b1ebe5e90f2c3913a47bc548747c",
+                "sha256:c11579638288e53fc94ad60022ff1b67865363e730ee41ad5e6f0a17188b327a",
+                "sha256:c150eaa3dadbb2b5339675b88d4573c1be3cb6f2c33a6c83387e10cc0bf05bd3",
+                "sha256:c53af463f4a40de78c58b8b2710ade243c81cbca641e34debf3396a9640d6ec1",
+                "sha256:cb763ceceae04803adcc4e2d80d611ef201c73da32d8f2722e9d0ab0c7f10768",
+                "sha256:cc75f58cdaf043fe6a7a6c04b3b5a0e694c6a9e24050967747251fb80d7bce0d",
+                "sha256:d80998ed59176e8cba74028762fbd9b9153b9afc71ea118e63bbf5d4d0f9552b",
+                "sha256:de31b5164d44ef4943db155b3e8e17929707cac1e5bd2f363e67a56e3af4af6e",
+                "sha256:e66399cf0fc07de4dce4f588fc25bfe84a6d1285cc544e67987d22663393926d",
+                "sha256:f0620511387790860b249b9241c2f13c3a80e21a73e0b861a2df24e9d6f56730",
+                "sha256:f4eae045e6ab2bb54ca279733fe4eb85f1effda392666308250714e01907f394",
+                "sha256:f92cdecb618e5fa4658aeb97d5eb3d2f47aa94ac6477c6daf0f306c5a3b9e6b1",
+                "sha256:f92f789e4f9241cd262ad7a555ca2c648a98178a953af117ef7fad46aa1d5591"
+            ],
+            "version": "==1.14.3"
+        },
         "chardet": {
             "hashes": [
                 "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "cryptography": {
+            "hashes": [
+                "sha256:0cacd3ef5c604b8e5f59bf2582c076c98a37fe206b31430d0cd08138aff0986e",
+                "sha256:192ca04a36852a994ef21df13cca4d822adbbdc9d5009c0f96f1d2929e375d4f",
+                "sha256:19ae795137682a9778892fb4390c07811828b173741bce91e30f899424b3934d",
+                "sha256:1b9b535d6b55936a79dbe4990b64bb16048f48747c76c29713fea8c50eca2acf",
+                "sha256:2a2ad24d43398d89f92209289f15265107928f22a8d10385f70def7a698d6a02",
+                "sha256:3be7a5722d5bfe69894d3f7bbed15547b17619f3a88a318aab2e37f457524164",
+                "sha256:49870684da168b90110bbaf86140d4681032c5e6a2461adc7afdd93be5634216",
+                "sha256:587f98ce27ac4547177a0c6fe0986b8736058daffe9160dcf5f1bd411b7fbaa1",
+                "sha256:5aca6f00b2f42546b9bdf11a69f248d1881212ce5b9e2618b04935b87f6f82a1",
+                "sha256:6b744039b55988519cc183149cceb573189b3e46e16ccf6f8c46798bb767c9dc",
+                "sha256:6b91cab3841b4c7cb70e4db1697c69f036c8bc0a253edc0baa6783154f1301e4",
+                "sha256:7598974f6879a338c785c513e7c5a4329fbc58b9f6b9a6305035fca5b1076552",
+                "sha256:7a279f33a081d436e90e91d1a7c338553c04e464de1c9302311a5e7e4b746088",
+                "sha256:95e1296e0157361fe2f5f0ed307fd31f94b0ca13372e3673fa95095a627636a1",
+                "sha256:9fc9da390e98cb6975eadf251b6e5fa088820141061bf041cd5c72deba1dc526",
+                "sha256:cc20316e3f5a6b582fc3b029d8dc03aabeb645acfcb7fc1d9848841a33265748",
+                "sha256:d1bf5a1a0d60c7f9a78e448adcb99aa101f3f9588b16708044638881be15d6bc",
+                "sha256:ed1d0760c7e46436ec90834d6f10477ff09475c692ed1695329d324b2c5cd547",
+                "sha256:ef9a55013676907df6c9d7dd943eb1770d014f68beaa7e73250fb43c759f4585"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.9"
         },
         "decorator": {
             "hashes": [
@@ -121,6 +187,28 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.1.1"
         },
+        "nassl": {
+            "hashes": [
+                "sha256:0f447fcec7cc64b16290c942c58d803ba04c72ce639566589e2c7572c00d0799",
+                "sha256:60512989cb4e9a8b343d530754ac2b134d5fac54ac968ab5b40068cb38a630d2",
+                "sha256:8873e3015ea16fb5194e7db2aa5b3cf569dcede41e509304e8c1a834742d09cf",
+                "sha256:935baca44868a50613654390d59afbd094ab072f635deccccdb00eb192b81eb2",
+                "sha256:b63b5cd45f5dde0797c5b0e9333304c53f4bbbdd379fa1995e83d77aec349e70",
+                "sha256:d2fd410ac63a8c1f6414fec494d15d479230de187ab5ff8472f84f00a9a75768",
+                "sha256:d94e6b809ef131152833c49521ac2260d9ddd44f6a4e22ebedf592d1a3619d6e",
+                "sha256:eb6f53a592f7c309ffe1b3737146ed1955766c34c7ece4666c4569087205eb7b"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.0.0"
+        },
+        "pycparser": {
+            "hashes": [
+                "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0",
+                "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.20"
+        },
         "pyjwt": {
             "hashes": [
                 "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e",
@@ -152,6 +240,13 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
         },
+        "sslyze": {
+            "hashes": [
+                "sha256:76a14ae3a497ba74ee24e93000fd4ed00e07bfd09dfd2d7aca9bf8e31dba83a5"
+            ],
+            "index": "pypi",
+            "version": "==3.0.8"
+        },
         "termcolor": {
             "hashes": [
                 "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"
@@ -165,6 +260,12 @@
             ],
             "index": "pypi",
             "version": "==3.0.2"
+        },
+        "tls-parser": {
+            "hashes": [
+                "sha256:83e4cb15b88b00fad1a856ff54731cc095c7e4f1ff90d09eaa24a5f48854da93"
+            ],
+            "version": "==1.2.2"
         },
         "urllib3": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The purpose of this tool is help you scan your Atlassian Connect app for complia
 This utility can be run as a python script or can be built as a Docker container. Choose the path that makes the most sense for your setup.
 
 ### Python Usage
-`pipenv run python main.py url-to-atlassian-connect-json --force_scan=True/False --debug=True/False`
+`pipenv run python main.py url-to-atlassian-connect-json --debug=True/False --out_dir=./out --skip_branding=True/False`
 
 Example: `pipenv run python3 main.py https://example.com/atlassian-connect.json`
 
@@ -19,15 +19,14 @@ Example: `pipenv run python3 main.py https://example.com/atlassian-connect.json`
 ### Arguments
 | Argument | Argument Description |
 |----------|----------------------|
-|--force_scan       | Forces a re-scan from Qualys to ensure the latest SSL/TLS results, **default: False**             |
 |--skip_branding    | Whether or not to skip branding checks, **default: False**                                        |
 |--out_dir          | The output directory where results are stored, **default: ./out**                                 |
 |--debug            | Sets logging to DEBUG for more verbose logging, **default: False**                                |
 
 ## Useful Information
 This tool assumes your connect app is reachable by the machine running this tool. If your connect app is not reachable, the tool will fail to produce any meaningful results. The following internet addresses are required to be accessible for this tool to work:
-* Your connect app's descriptor URL and all URLs referenced in the connect descriptor
-* Qualys SSL Labs API (https://api.ssllabs.com)
+* Your connect app's descriptor URL
+* All URLs referenced inside your connect app descriptor
 
 This tool will make network requests on from your computer. Please ensure this is allowed from your organization if running this from a monitored network.
 
@@ -42,4 +41,4 @@ To run the entire test suite:
 Tests may take a few minutes to run as we rely on the Qualys API to return results back to us to confirm functionality.
 
 ## Issues / Feedback?
-Found a bug or have an idea for an improvement? Create an issue following the template provided.
+Found a bug or have an idea for an improvement? Create an issue via the [issue tracker](https://github.com/atlassian-labs/connect-security-req-tester/issues).

--- a/analyzers/descriptor_analyzer.py
+++ b/analyzers/descriptor_analyzer.py
@@ -1,4 +1,3 @@
-import json
 import re
 from distutils import util
 
@@ -16,7 +15,6 @@ class DescriptorAnalyzer(object):
     def __init__(self, desc_scan, requirements):
         self.scan = desc_scan
         self.reqs = requirements
-        self.proof = json.dumps(self.scan.to_json(), indent=3)
 
     def _check_cache_headers(self):
         passed = True

--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ from scans.descriptor_scan import DescriptorScan
 from scans.tls_scan import TlsScan
 
 
-def main(descriptor_url, force_scan=False, skip_branding=False, debug=False, out_dir='out'):
+def main(descriptor_url, skip_branding=False, debug=False, out_dir='out'):
     # Setup our logging
     setup_logging(debug)
     # Validate and fetch the provided connect descriptor to confirm it works
@@ -24,7 +24,7 @@ def main(descriptor_url, force_scan=False, skip_branding=False, debug=False, out
     tls_scan = TlsScan(base_url)
     descriptor_scan = DescriptorScan(descriptor_url, descriptor)
 
-    tls_res = tls_scan.scan(force_scan)
+    tls_res = tls_scan.scan()
     descriptor_res = descriptor_scan.scan()
 
     # Analyze the results from the scans
@@ -65,6 +65,8 @@ def setup_logging(debug):
         format=logging_format,
         level=logging.DEBUG if debug else logging.INFO
     )
+    # filelock was getting greedy with logging, turning it off to reduce noise
+    logging.getLogger('filelock').propagate = True if debug else False
 
 
 if __name__ == '__main__':

--- a/models/tls_result.py
+++ b/models/tls_result.py
@@ -1,12 +1,5 @@
-from jsonobject import (BooleanProperty, DefaultProperty, DictProperty,
-                        IntegerProperty, JsonObject, ListProperty,
-                        StringProperty)
-
-
-class IpResult(JsonObject):
-    protocols = ListProperty(StringProperty())
-    hsts = DefaultProperty()
-    cert_grade = StringProperty()
+from jsonobject import (BooleanProperty, DefaultProperty, IntegerProperty,
+                        JsonObject, ListProperty, StringProperty)
 
 
 class TlsResult(JsonObject):
@@ -14,4 +7,5 @@ class TlsResult(JsonObject):
     protocols = ListProperty(StringProperty())
     hsts_present = BooleanProperty()
     trusted = BooleanProperty()
-    scan_results = DictProperty(IpResult)
+    scan_results = DefaultProperty()
+    domain = StringProperty()

--- a/tests/examples/tls_scan_expired.json
+++ b/tests/examples/tls_scan_expired.json
@@ -1,25 +1,12 @@
 {
    "ips_scanned": 1,
    "protocols": [
-      "TLS 1.2",
-      "TLS 1.1",
-      "TLS 1.0"
+      "TLS_1_2",
+      "TLS_1_1",
+      "TLS_1_0"
    ],
    "hsts_present": false,
    "trusted": false,
    "scan_results": {
-      "104.154.89.105": {
-         "protocols": [
-            "TLS 1.0",
-            "TLS 1.1",
-            "TLS 1.2"
-         ],
-         "hsts": {
-            "LONG_MAX_AGE": 15552000,
-            "status": "absent",
-            "directives": {}
-         },
-         "cert_grade": "T"
-      }
    }
 }

--- a/tests/examples/tls_scan_hsts.json
+++ b/tests/examples/tls_scan_hsts.json
@@ -1,31 +1,12 @@
 {
    "ips_scanned": 1,
    "protocols": [
-      "TLS 1.2",
-      "TLS 1.1",
-      "TLS 1.0"
+      "TLS_1_2",
+      "TLS_1_1",
+      "TLS_1_0"
    ],
    "hsts_present": true,
    "trusted": true,
    "scan_results": {
-      "104.154.89.105": {
-         "protocols": [
-            "TLS 1.0",
-            "TLS 1.1",
-            "TLS 1.2"
-         ],
-         "hsts": {
-            "LONG_MAX_AGE": 15552000,
-            "header": "max-age=15768000; includeSubDomains",
-            "status": "present",
-            "maxAge": 15768000,
-            "includeSubDomains": true,
-            "directives": {
-               "includesubdomains": "",
-               "max-age": "15768000"
-            }
-         },
-         "cert_grade": "B"
-      }
    }
 }

--- a/tests/examples/tls_scan_valid.json
+++ b/tests/examples/tls_scan_valid.json
@@ -1,53 +1,8 @@
 {
   "ips_scanned": 3,
-  "protocols": ["TLS 1.2", "TLS 1.3"],
+  "protocols": ["TLS_1_2", "TLS_1_3"],
   "hsts_present": true,
   "trusted": true,
   "scan_results": {
-    "18.234.32.198": {
-      "protocols": ["TLS 1.2", "TLS 1.3"],
-      "hsts": {
-        "LONG_MAX_AGE": 15552000,
-        "header": "max-age=63072000; preload",
-        "status": "present",
-        "maxAge": 63072000,
-        "preload": true,
-        "directives": {
-          "max-age": "63072000",
-          "preload": ""
-        }
-      },
-      "cert_grade": "A+"
-    },
-    "18.234.32.199": {
-      "protocols": ["TLS 1.2", "TLS 1.3"],
-      "hsts": {
-        "LONG_MAX_AGE": 15552000,
-        "header": "max-age=63072000; preload",
-        "status": "present",
-        "maxAge": 63072000,
-        "preload": true,
-        "directives": {
-          "max-age": "63072000",
-          "preload": ""
-        }
-      },
-      "cert_grade": "A+"
-    },
-    "18.234.32.197": {
-      "protocols": ["TLS 1.2", "TLS 1.3"],
-      "hsts": {
-        "LONG_MAX_AGE": 15552000,
-        "header": "max-age=63072000; preload",
-        "status": "present",
-        "maxAge": 63072000,
-        "preload": true,
-        "directives": {
-          "max-age": "63072000",
-          "preload": ""
-        }
-      },
-      "cert_grade": "A+"
-    }
   }
 }

--- a/tests/test_tls_analyzer.py
+++ b/tests/test_tls_analyzer.py
@@ -33,7 +33,7 @@ def test_hsts_valid():
 
     assert res.req1.passed is False
     assert res.req1.description == [TLS_PROTOCOLS]
-    assert res.req1.proof == ['104.154.89.105 - [\'TLS 1.0\', \'TLS 1.1\', \'TLS 1.2\']']
+    assert res.req1.proof == ['Protocols Found: [\'TLS_1_2\', \'TLS_1_1\', \'TLS_1_0\']']
     assert res.req3.passed is True
     assert res.req3.description == [NO_ISSUES]
     assert res.req3.proof == []
@@ -50,9 +50,9 @@ def test_expired_cert():
     assert res.req1.passed is False
     assert res.req1.description == [TLS_PROTOCOLS, HSTS_MISSING]
     assert res.req1.proof == [
-        '104.154.89.105 - [\'TLS 1.0\', \'TLS 1.1\', \'TLS 1.2\']',
-        '104.154.89.105 - {\'LONG_MAX_AGE\': 15552000, \'status\': \'absent\', \'directives\': {}}'
+        'Protocols Found: [\'TLS_1_2\', \'TLS_1_1\', \'TLS_1_0\']',
+        'We did not detect an HSTS header when scanning your app.'
     ]
     assert res.req3.passed is False
     assert res.req3.description == [CERT_NOT_VALID]
-    assert res.req3.proof == ['104.154.89.105 - Failing Grade of T']
+    assert res.req3.proof == ['Your app presented an HTTPS certificate that was not valid.']

--- a/tests/test_tls_scan.py
+++ b/tests/test_tls_scan.py
@@ -1,68 +1,52 @@
-from collections import defaultdict
-
 from scans.tls_scan import TlsScan
 
 
-def test_init_valid():
-    # We expect to call this with the URL of the connect descriptor,
-    # so we will call it as such with the tests
+def test_init_domain_valid():
     url = 'https://atlassian.com/random/atlassian-connect.json'
     scanner = TlsScan(url)
 
-    assert scanner.base_url == url
-    assert scanner.session is not None
+    assert scanner.domain == 'atlassian.com'
 
 
 def test_tls_valid():
     url = 'https://atlassian.com'
     scanner = TlsScan(url)
-    res = scanner.scan().to_json()
+    res = scanner.scan()
 
-    ips_scanned = defaultdict()
-    for ip in res['scan_results']:
-        ips_scanned[ip] = {
-            'protocols': res['scan_results'][ip]['protocols'],
-            'hsts': {
-                'LONG_MAX_AGE': 15552000,
-                'header': 'max-age=63072000; preload',
-                'status': 'present',
-                'maxAge': 63072000,
-                'preload': True,
-                'directives': {
-                    'max-age': '63072000',
-                    'preload': ''
-                }
-            },
-            'cert_grade': 'A+'
-        }
+    expected_protos = ['TLS_1_2', 'TLS_1_3']
 
-    expected_res = {
-        'ips_scanned': 3,
-        'protocols': res['protocols'],
-        'hsts_present': True,
-        'trusted': True,
-        'scan_results': ips_scanned
-    }
-    expected_protos = ['TLS 1.2', 'TLS 1.3']
-
-    # Protocols may end up any order, this ensures we have the protocols we expect
-    assert all(proto in expected_protos for proto in res['protocols'])
-    assert res == expected_res
+    assert res.ips_scanned == 1
+    assert all(proto in expected_protos for proto in res.protocols)
+    assert res.hsts_present is True
+    assert res.trusted is True
+    assert res.scan_results is not None
 
 
 def test_hsts_valid():
     url = 'https://hsts.badssl.com'
     scanner = TlsScan(url)
-    res = scanner.scan().to_json()
+    res = scanner.scan()
 
-    assert res['hsts_present'] is True
-    assert res['trusted'] is True
-    assert res['ips_scanned'] == 1
+    assert res.hsts_present is True
+    assert res.trusted is True
+    assert res.ips_scanned == 1
+    assert res.scan_results is not None
 
 
-def test_untrusted_cert():
-    url = 'https://expired.badssl.com/'
-    scanner = TlsScan(url)
-    res = scanner.scan().to_json()
+def test_untrusted_certs():
+    # A handful of different ways an HTTPS cert can be invalid
+    urls = [
+        'https://expired.badssl.com/',
+        'https://wrong.host.badssl.com/',
+        'https://self-signed.badssl.com/',
+        'https://untrusted-root.badssl.com/'
+    ]
 
-    assert res['trusted'] is False
+    for url in urls:
+        scanner = TlsScan(url)
+        res = scanner.scan()
+
+        assert res.trusted is False
+        assert res.hsts_present is False
+        assert res.ips_scanned == 1
+        assert res.scan_results is not None


### PR DESCRIPTION
## Description
Replace SSL Labs with a local SSL/TLS scanning solution. SSL Labs has been under heavy load over the last few days which has made the tool fail for various reasons outside of our control. This change rips out SSL Labs and instead uses https://github.com/nabla-c0d3/sslyze instead.

Downsides:
* sslyze cannot detect if an HTTPS certificate has been revoked, and this is a known shortcoming

## Changes
* Replace all of `tls_scan.py` with sslyze and their implementation of SSL scanning
* Adjust the `tls_result.py` model with less fields as sslyze does not scan every IP that resolved, just the first
* Adjust the `tls_analyzer.py` analyzer to handle the new fields returned from the SSL/TLS Scan'
* Stop the `filelock` logger from producing logs as they were irrelevant
* Removed the `--force_scan` flag as we will ALWAYS fetch the most recent SSL/TLS configuration as we are doing the scanning now
* Update tests to play nicely with the new changes

## Other notes
* This reduces scan times to be typically under 60 seconds whereas before a scan would take anywhere from 60 seconds to 20 minutes