### PR TITLE
Fix docker builds and add tests to attempt to build the container

### DIFF
--- a/.github/workflows/csrt-lint-and-test.yml
+++ b/.github/workflows/csrt-lint-and-test.yml
@@ -33,3 +33,5 @@ jobs:
     - name: Test with pytest
       run: |
         pipenv run test
+    - name: Build docker image
+      uses: docker/build-push-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM python:3.8-alpine
+FROM python:3.8-slim
 
 RUN pip install pipenv
-RUN apk add build-base
+RUN apt update && apt install build-essential -y
 
-RUN adduser -D app
+RUN useradd -m app
 USER app
 
 WORKDIR /app


### PR DESCRIPTION
## Description
Docker container builds are currently failing due to `sslyze` not playing well with Alpine linux. Switch our docker container back over the to the `python-slim` variant which is based on Debian and seems to be more compatible.

## Changes
* Update dockerfile
* Add in tests to ensure the docker container builds so this doesn't happen again