### PR TITLE
Now scanning invalid https certs and descriptors without scopes

### DIFF
--- a/main.py
+++ b/main.py
@@ -65,8 +65,10 @@ def setup_logging(debug):
         format=logging_format,
         level=logging.DEBUG if debug else logging.INFO
     )
-    # filelock was getting greedy with logging, turning it off to reduce noise
+    # Turn off extra logging from filelock and HTTPS warnings when not in debug mode
+    logging.captureWarnings(True)
     logging.getLogger('filelock').propagate = True if debug else False
+    logging.getLogger('py.warnings').propagate = True if debug else False
 
 
 if __name__ == '__main__':

--- a/scans/descriptor_scan.py
+++ b/scans/descriptor_scan.py
@@ -29,6 +29,7 @@ class DescriptorScan(object):
         session.headers.update(
             {'User-Agent': 'Atlassian CSRT (https://github.com/atlassian-labs/connect-security-req-tester)'}
         )
+        session.verify = False
         return session
 
     def _get_links(self):
@@ -142,7 +143,7 @@ class DescriptorScan(object):
             base_url=self.base_url,
             app_descriptor_url=self.descriptor_url,
             app_descriptor=self.descriptor,
-            scopes=self.descriptor['scopes'],
+            scopes=self.descriptor.get('scopes', []),
             links=self.links,
             scan_results={}
         )

--- a/utils.py
+++ b/utils.py
@@ -22,12 +22,13 @@ def validate_and_resolve_descriptor(url):
         sys.exit(1)
     # Fetch the descriptor, ensure file is JSON, reachable, and contains required fields
     res = None
-    required_fields = ['baseUrl', 'key', 'name', 'scopes']
+    required_fields = ['baseUrl', 'key', 'name']
     try:
         session = requests.Session()
         session.headers.update(
             {'User-Agent': 'Atlassian CSRT (https://github.com/atlassian-labs/connect-security-req-tester)'}
         )
+        session.verify = False
         res = session.get(url)
         res.raise_for_status()
         res = res.json()


### PR DESCRIPTION
## Description
CSRT would fail to scan an app without a valid HTTPS certificate
CSRT would fail to scan an app without a defined `scopes` section of the descriptor

Fixes #6 #7 

## Testing
- [x] Ran and updated tests for my changes
- [x] Run linting