### PR TITLE
Fixing report bugs and handle errors better

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -380,11 +380,11 @@
         },
         "packaging": {
             "hashes": [
-                "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8",
-                "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"
+                "sha256:05af3bb85d320377db281cf254ab050e1a7ebcbf5410685a9a407e18a1f81236",
+                "sha256:eb41423378682dadb7166144a4926e443093863024de508ca5c9737d6bc08376"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.4"
+            "version": "==20.7"
         },
         "pluggy": {
             "hashes": [

--- a/analyzers/branding_analyzer.py
+++ b/analyzers/branding_analyzer.py
@@ -48,7 +48,7 @@ class BrandingAnalyzer(object):
 
             if sub_test or domain_test:
                 proof.append(
-                    f"{link} - Contains a denied word in the subdomain or primary domain"
+                    f"{link} | Contains a denied word in the subdomain or primary domain"
                 )
                 passed = False
 

--- a/analyzers/descriptor_analyzer.py
+++ b/analyzers/descriptor_analyzer.py
@@ -27,7 +27,7 @@ class DescriptorAnalyzer(object):
             cache_headers = [x.strip().lower() for x in cache_headers]
             directives = all(item in cache_headers for item in REQ_CACHE_HEADERS)
             if not directives:
-                proof.append(f"{link} - {scan_res[link].cache_header}")
+                proof.append(f"{link} | Cache header: {scan_res[link].cache_header}")
             passed = passed and directives
 
         return passed, proof
@@ -41,7 +41,7 @@ class DescriptorAnalyzer(object):
             ref_headers = [x.strip().lower() for x in ref_headers]
             policy = ref_headers[0] not in REF_DENYLIST if ref_headers[0] != 'header missing' else False
             if not policy:
-                proof.append(f"{link} - {scan_res[link].referrer_header}")
+                proof.append(f"{link} | Referrer header: {scan_res[link].referrer_header}")
             passed = passed and policy
 
         return passed, proof
@@ -61,7 +61,7 @@ class DescriptorAnalyzer(object):
                 httponly = bool(util.strtobool(parsed.group(4)))
 
                 if not secure or not httponly:
-                    proof.append(f"{link} - {cookie}")
+                    proof.append(f"{link} | Cookie: {cookie}")
                 passed = passed and secure and httponly
 
         return passed, proof
@@ -72,9 +72,11 @@ class DescriptorAnalyzer(object):
         scan_res = self.scan.scan_results
         for link in scan_res:
             res_code = int(scan_res[link].res_code)
+            auth_header = scan_res[link].auth_header
+            req_method = scan_res[link].req_method
             if res_code >= 200 and res_code < 400:
                 passed = False
-                proof_text = f"{link} - Using an invalid JWT token" if scan_res[link].fake_jwt else link
+                proof_text = f"{link} | Res Code: {res_code} Req Method: {req_method} Auth Header: {auth_header}"
                 proof.append(proof_text)
 
         return passed, proof

--- a/main.py
+++ b/main.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 
 import fire
 
@@ -34,7 +35,8 @@ def main(descriptor_url, skip_branding=False, debug=False, out_dir='out'):
         app_descriptor_url=descriptor_res.app_descriptor_url,
         requirements=Requirements(),
         tls_scan_raw=json.dumps(tls_res.to_json(), indent=3),
-        descriptor_scan_raw=json.dumps(descriptor_res.to_json(), indent=3)
+        descriptor_scan_raw=json.dumps(descriptor_res.to_json(), indent=3),
+        errors=descriptor_res.link_errors
     )
 
     logging.info('Starting analysis of results...')
@@ -54,6 +56,11 @@ def main(descriptor_url, skip_branding=False, debug=False, out_dir='out'):
     # Generate a report based on the analyzed results against Security Requirements
     generator = ReportGenerator(results, out_dir)
     generator.save_report()
+
+    if results.errors:
+        errors: str = '\n'.join(descriptor_res.link_errors)
+        logging.error(f"The following links caused errors:\n{errors}")
+        sys.exit(1)
 
 
 def setup_logging(debug):

--- a/models/descriptor_result.py
+++ b/models/descriptor_result.py
@@ -1,12 +1,13 @@
-from jsonobject import (BooleanProperty, DefaultProperty, DictProperty,
-                        JsonObject, ListProperty, StringProperty)
+from jsonobject import (DefaultProperty, DictProperty, JsonObject,
+                        ListProperty, StringProperty)
 
 
 class DescriptorLink(JsonObject):
     cache_header = StringProperty()
     referrer_header = StringProperty()
     session_cookies = ListProperty(StringProperty())
-    fake_jwt = BooleanProperty()
+    auth_header = StringProperty()
+    req_method = StringProperty()
     res_code = StringProperty()
 
 
@@ -18,4 +19,5 @@ class DescriptorResult(JsonObject):
     app_descriptor = DefaultProperty()
     scopes = ListProperty(StringProperty())
     links = ListProperty(StringProperty())
+    link_errors = ListProperty(StringProperty())
     scan_results = DictProperty(DescriptorLink)

--- a/models/requirements.py
+++ b/models/requirements.py
@@ -39,3 +39,4 @@ class Results(JsonObject):
     requirements = ObjectProperty(Requirements)
     tls_scan_raw = StringProperty()
     descriptor_scan_raw = StringProperty()
+    errors = ListProperty(StringProperty())

--- a/reports/generator.py
+++ b/reports/generator.py
@@ -83,7 +83,7 @@ class ReportGenerator(object):
 
         return out.getvalue()
 
-    def save_report(self):
+    def _create_html_report(self) -> str:
         markdown_report = self._jinja_render(
             template=MARKDOWN_TEMPLATE,
             today=datetime.now(),
@@ -93,21 +93,25 @@ class ReportGenerator(object):
         )
         markdown_to_html = markdown2.markdown(
             markdown_report,
-            extras=['fenced-code-blocks', 'target-blank-links', 'link-patterns'],
+            extras=['fenced-code-blocks', 'target-blank-links', 'link-patterns', 'code-friendly'],
             link_patterns=LINK_PATTERNS
         )
         final_report = self._jinja_render(
             template=HTML_TEMPLATE,
             report_body=markdown_to_html
         )
+        return final_report
+
+    def save_report(self):
         json_report = self._create_json_report()
         csv_report = self._create_csv_report(json_report)
+        html_report = self._create_html_report()
 
         html_name = f"{self.file_name}.html"
         json_name = f"{self.file_name}.json"
         csv_name = f"{self.file_name}.csv"
 
-        self._write_output(final_report, html_name)
+        self._write_output(html_report, html_name)
         if json_report:
             self._write_output(json.dumps(json_report, indent=3), json_name)
         if csv_report:

--- a/reports/standard_report.md
+++ b/reports/standard_report.md
@@ -26,7 +26,7 @@ Description:
 
 Proof:
 {% if results.requirements[req].proof %}
-* {{ results.requirements[req].proof | join('\n\n* ') }}
+* {{ results.requirements[req].proof | join('\n\n* ') | replace('|', '\n\n\t* ') }}
 {% elif not results.requirements[req].was_scanned() %}
 * {{ constants.NO_SCAN_PROOF }}
 {% else %}
@@ -37,6 +37,11 @@ Proof:
 {% endfor %}
 
 ## Appendix
+### Scan Errors
+The following links could not be scanned due to an error:
+
+* {{ results.errors | join('\n\n* ') }}
+
 ### SSL/TLS Scan Raw Output
 Obtained via the [Qualys SSL Labs API](https://www.ssllabs.com/ssltest/)
 

--- a/scans/tls_scan.py
+++ b/scans/tls_scan.py
@@ -30,7 +30,7 @@ class TlsScan(object):
             server_info = ServerConnectivityTester().perform(location)
         except ConnectionToServerFailed as e:
             logging.error(f"SSL/TLS Scan could not connect to: {self.domain}\n{e.error_message}")
-            return
+            return None
 
         return server_info
 

--- a/tests/examples/desc_scan_authn.json
+++ b/tests/examples/desc_scan_authn.json
@@ -491,99 +491,113 @@
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "200"
+         "auth_header": "",
+         "res_code": "200",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-admin-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "JWT sometexthere",
+         "res_code": "200",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/space-tools-tab?space_key=test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-byline-item": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-spaceview/test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-post-install-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/javascript:alert(2);": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/macro": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-dialog-content": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/blueprints/blueprint.xml": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/web-panel": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-config-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/issue-created": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/render-map?pageTitle=test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       }
    }
 }

--- a/tests/examples/desc_scan_cache_headers.json
+++ b/tests/examples/desc_scan_cache_headers.json
@@ -491,99 +491,113 @@
          "cache_header": "Header missing",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "401"
+         "auth_header": "",
+         "res_code": "401",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-admin-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/space-tools-tab?space_key=test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-byline-item": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-spaceview/test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-post-install-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/javascript:alert(2);": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/macro": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-dialog-content": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/blueprints/blueprint.xml": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/web-panel": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-config-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/issue-created": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/render-map?pageTitle=test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       }
    }
 }

--- a/tests/examples/desc_scan_cookies.json
+++ b/tests/examples/desc_scan_cookies.json
@@ -493,99 +493,113 @@
          "session_cookies": [
             "JSESSIONID; Domain=9ee0fd043609.ngrok.io; Secure=False; HttpOnly=True"
          ],
-         "fake_jwt": false,
-         "res_code": "401"
+         "auth_header": "",
+         "res_code": "401",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-admin-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/space-tools-tab?space_key=test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-byline-item": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-spaceview/test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-post-install-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/javascript:alert(2);": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/macro": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-dialog-content": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/blueprints/blueprint.xml": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/web-panel": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-config-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/issue-created": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/render-map?pageTitle=test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       }
    }
 }

--- a/tests/examples/desc_scan_referrer_headers.json
+++ b/tests/examples/desc_scan_referrer_headers.json
@@ -491,99 +491,113 @@
          "cache_header": "no-cache, no-store",
          "referrer_header": "Header missing",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "401"
+         "auth_header": "",
+         "res_code": "401",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-admin-page": {
          "cache_header": "no-cache, no-store",
-         "referrer_header": "origin",
+         "referrer_header": "unsafe-url",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/space-tools-tab?space_key=test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-byline-item": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-spaceview/test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-post-install-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/javascript:alert(2);": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/macro": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-dialog-content": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/blueprints/blueprint.xml": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/web-panel": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-config-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/issue-created": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/render-map?pageTitle=test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       }
    }
 }

--- a/tests/examples/desc_scan_valid.json
+++ b/tests/examples/desc_scan_valid.json
@@ -491,99 +491,113 @@
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "401"
+         "auth_header": "",
+         "res_code": "401",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-admin-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/space-tools-tab?space_key=test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-byline-item": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-spaceview/test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "404"
+         "auth_header": "",
+         "res_code": "404",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-post-install-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/javascript:alert(2);": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/macro": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-dialog-content": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/blueprints/blueprint.xml": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/web-panel": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/my-config-page": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/issue-created": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       },
       "https://bbc7069740af.ngrok.io/render-map?pageTitle=test": {
          "cache_header": "no-cache, no-store",
          "referrer_header": "origin",
          "session_cookies": [],
-         "fake_jwt": false,
-         "res_code": "429"
+         "auth_header": "",
+         "res_code": "429",
+         "req_method": "GET"
       }
    }
 }

--- a/tests/test_branding_analyzer.py
+++ b/tests/test_branding_analyzer.py
@@ -25,7 +25,7 @@ def test_bad_domain():
     assert res.req16.passed is False
     assert res.req16.description == [BRANDING_ISSUE]
     assert res.req16.title == REQ_TITLES['16']
-    assert res.req16.proof == [f"{links[0]} - Contains a denied word in the subdomain or primary domain"]
+    assert res.req16.proof == [f"{links[0]} | Contains a denied word in the subdomain or primary domain"]
 
 
 def test_bad_name():
@@ -54,7 +54,7 @@ def test_bad_name_and_links():
     assert res.req16.description == [BRANDING_ISSUE]
     assert res.req16.title == REQ_TITLES['16']
     assert res.req16.proof == [
-        f"{links[0]} - Contains a denied word in the subdomain or primary domain",
+        f"{links[0]} | Contains a denied word in the subdomain or primary domain",
         f"App Name ({name}) starts with or contains a denied word"
     ]
 

--- a/tests/test_descriptor_analyzer.py
+++ b/tests/test_descriptor_analyzer.py
@@ -40,7 +40,7 @@ def test_bad_cache_header():
 
     assert res.req2.passed is False
     assert res.req2.description == [MISSING_CACHE_HEADERS]
-    assert res.req2.proof == ['https://bbc7069740af.ngrok.io/installed - Header missing']
+    assert res.req2.proof == ['https://bbc7069740af.ngrok.io/installed | Cache header: Header missing']
     assert res.req5.passed is True
     assert res.req5.description == [NO_ISSUES]
     assert res.req5.proof == []
@@ -71,7 +71,10 @@ def test_bad_referrer_header():
     assert res.req11.proof == []
     assert res.req12.passed is False
     assert res.req12.description == [MISSING_REF_HEADERS]
-    assert res.req12.proof == ['https://bbc7069740af.ngrok.io/installed - Header missing']
+    assert res.req12.proof == [
+        'https://bbc7069740af.ngrok.io/installed | Referrer header: Header missing',
+        'https://bbc7069740af.ngrok.io/my-admin-page | Referrer header: unsafe-url'
+    ]
 
 
 def test_bad_cookies():
@@ -90,7 +93,7 @@ def test_bad_cookies():
     assert res.req5.proof == []
     assert res.req11.passed is False
     assert res.req11.description == [MISSING_ATTRS_SESSION_COOKIE]
-    assert res.req11.proof == ['https://bbc7069740af.ngrok.io/installed - JSESSIONID; Domain=9ee0fd043609.ngrok.io; Secure=False; HttpOnly=True']
+    assert res.req11.proof == ['https://bbc7069740af.ngrok.io/installed | Cookie: JSESSIONID; Domain=9ee0fd043609.ngrok.io; Secure=False; HttpOnly=True']
     assert res.req12.passed is True
     assert res.req12.description == [NO_ISSUES]
     assert res.req12.proof == []
@@ -109,7 +112,10 @@ def test_bad_authn():
     assert res.req2.proof == []
     assert res.req5.passed is False
     assert res.req5.description == [MISSING_AUTHN_AUTHZ]
-    assert res.req5.proof == ['https://bbc7069740af.ngrok.io/installed']
+    assert res.req5.proof == [
+        'https://bbc7069740af.ngrok.io/installed | Res Code: 200 Req Method: GET Auth Header: ',
+        'https://bbc7069740af.ngrok.io/my-admin-page | Res Code: 200 Req Method: GET Auth Header: JWT sometexthere'
+    ]
     assert res.req11.passed is True
     assert res.req11.description == [NO_ISSUES]
     assert res.req11.proof == []

--- a/tests/test_descriptor_scan.py
+++ b/tests/test_descriptor_scan.py
@@ -33,7 +33,8 @@ def create_scan_results(links):
             'cache_header': 'Header missing',
             'referrer_header': 'Header missing',
             'session_cookies': [],
-            'fake_jwt': False,
+            'auth_header': None,
+            'req_method': 'GET',
             'res_code': '200' if '?' in link else '204'
         }
     return res
@@ -72,7 +73,8 @@ def test_scan_valid_app():
         'app_descriptor': descriptor,
         'scopes': descriptor['scopes'],
         'links': links,
-        'scan_results': scan_res
+        'scan_results': scan_res,
+        'link_errors': []
     }, sort_keys=True)
 
     assert res == expected_res


### PR DESCRIPTION
## Description of Change
* Update markdown conversion to no longer produce random italicized results
* Handle if an app link cannot be requested, and track the error through the scan
   * Subsequently, fail the scan if any link cannot be scanned, but still produce a report indicating the error - We did all that work, might as well still produce a report!
* Generally clean-up HTML report language and formatting to make reviewing easier
* Updated tests to handle the new error-safe reporting objects

## Fixes
* Fixes #15 

## Did you test your changes?
- [x] Yes

## Reviewers
@anshumanbh @alisha-m 
