### PR TITLE
[AUT-175] Fix branding and reporting errors for CSRT output

### DIFF
--- a/main.py
+++ b/main.py
@@ -56,7 +56,7 @@ def main(descriptor_url, skip_branding=False, debug=False, out_dir='out'):
     logging.info('Finished analysis')
 
     # Generate a report based on the analyzed results against Security Requirements
-    generator = ReportGenerator(results, out_dir)
+    generator = ReportGenerator(results, out_dir, skip_branding)
     generator.save_report()
 
     if results.errors:

--- a/reports/standard_report.md
+++ b/reports/standard_report.md
@@ -16,6 +16,7 @@ Report generated for:
 ## Scan Results
 
 {% for req in results.requirements %}
+{% if not skip_branding or req != '16' %}
 ### Requirement {{ req }} - {{ results.requirements[req].title }}
 
 Passed: {% if not results.requirements[req].was_scanned() %} **No Scan Performed** {% else %} **{{ results.requirements[req].passed }}** {% endif %}
@@ -34,16 +35,19 @@ Proof:
 {% endif %}
 
 ---
+{% endif %}
 {% endfor %}
 
 ## Appendix
+{% if results.errors %}
 ### Scan Errors
 The following links could not be scanned due to an error:
 
 * {{ results.errors | join('\n\n* ') }}
+{% endif %}
 
 ### SSL/TLS Scan Raw Output
-Obtained via the [Qualys SSL Labs API](https://www.ssllabs.com/ssltest/)
+Obtained via: [sslyze](https://github.com/nabla-c0d3/sslyze)
 
 ```
 {{ results['tls_scan_raw'] }}


### PR DESCRIPTION
## Description of Change
* Fix reporting formatting errors that resulted in Requirement Titles being `None`
* Fix report to show that we no longer use Qualys for SSL/TLS checking
* No longer report on branding issues with `--skip_branding` is specified (Req 16 is completely removed from the report now)
* Always create output files even when no vulns were found (downstream requirement)

## Fixes
This change does not fix or address any public GH issues.

## Did you test your changes?
- [x] Yes

N/A

## Reviewers
@anshumanbh 
