### PR TITLE
[AUT-181] HSTS is now properly handled when failing to scan

### DIFF
--- a/scans/tls_scan.py
+++ b/scans/tls_scan.py
@@ -90,9 +90,11 @@ class TlsScan(object):
     def _get_hsts_info(self, scan_res: List[ServerScanResult]) -> bool:
         hsts_present = True
         for res in scan_res:
-            headers = res.scan_commands_results[ScanCommand.HTTP_HEADERS]
-            if not headers.strict_transport_security_header:
-                hsts_present = False
+            headers = res.scan_commands_results.get(ScanCommand.HTTP_HEADERS, False)
+            # Take advantage of short circuiting here to make this check smaller
+            # Check if we got any HTTP HEADERS first, then see if HSTS was set -- We use an "and" here to fail the check
+            # if any of the returned scans were missing HSTS headers as every IP scanned should have HSTS set per req #1
+            hsts_present = bool(headers and hsts_present and headers.strict_transport_security_header)
 
         return hsts_present
 


### PR DESCRIPTION
## Description of Change
* Updated the SSL/TLS scan to handle when an HTTP request times out causing HTTP Header information to be missing from the scan result
   * We are now much more defensive when querying scan results from sslyze as scans can randomly fail it seems

## Fixes
Internal bugfix, no public GH issue is being fixed here

## Did you test your changes?
- [x] Yes

No new tests, hard to find an externally facing app that has this weird edge case present

## Reviewers
@anshumanbh 
