### PR TITLE
[AUT-167] Proper Heroku TLS checking, split requirement 1

### DIFF
--- a/models/requirements.py
+++ b/models/requirements.py
@@ -13,7 +13,8 @@ class RequirementsResult(JsonObject):
 
 
 class Requirements(JsonObject):
-    req1 = ObjectProperty(RequirementsResult, name='1')
+    req1_1 = ObjectProperty(RequirementsResult, name='1.1')
+    req1_2 = ObjectProperty(RequirementsResult, name='1.2')
     req2 = ObjectProperty(RequirementsResult, name='2')
     req3 = ObjectProperty(RequirementsResult, name='3')
     req4 = ObjectProperty(RequirementsResult, name='4')

--- a/reports/constants.py
+++ b/reports/constants.py
@@ -1,5 +1,6 @@
 REQ_TITLES = {
-    '1': 'Transport Layer Security',
+    '1.1': 'Transport Layer Security',
+    '1.2': 'HSTS',
     '2': 'Cache Control',
     '3': 'Validity of Domain Registration and TLS Certificates',
     '4': 'Domain and Subdomain Takeover',
@@ -30,7 +31,8 @@ MISSING_AUTHN_AUTHZ = 'One or more endpoints returned a <400 status code without
 BRANDING_ISSUE = 'Your app name or domain contained words that are not allowed. Please refer to our branding guidelines at: https://developer.atlassian.com/platform/marketplace/atlassian-brand-guidelines-for-marketplace-vendors/#app-names for more information.'
 
 REQ_RECOMMENDATION = {
-    '1': 'Refer to https://developer.atlassian.com/platform/marketplace/security-requirements-more-info/#transport-layer-security:~:text=requirement.-,Transport%20layer%20security for more information.',
+    '1.1': 'Refer to https://developer.atlassian.com/platform/marketplace/security-requirements-more-info/#transport-layer-security:~:text=requirement.-,Transport%20layer%20security for more information.',
+    '1.2': 'Refer to https://developer.atlassian.com/platform/marketplace/security-requirements-more-info/#transport-layer-security:~:text=requirement.-,Transport%20layer%20security for more information.',
     '2': 'Refer to https://developer.atlassian.com/platform/marketplace/security-requirements-more-info/#cache-control for more information.',
     '3': 'Refer to https://developer.atlassian.com/platform/marketplace/security-requirements-more-info/#validity-of-domain-registration---tls-certificates for more information.',
     '4': 'Refer to https://developer.atlassian.com/platform/marketplace/security-requirements-more-info/#domain-and-subdomain-takeover for more information.',

--- a/tests/examples/tls_scan_expired.json
+++ b/tests/examples/tls_scan_expired.json
@@ -8,5 +8,6 @@
    "hsts_present": false,
    "trusted": false,
    "scan_results": {
-   }
+   },
+   "domain": "example.com"
 }

--- a/tests/examples/tls_scan_heroku.json
+++ b/tests/examples/tls_scan_heroku.json
@@ -1,0 +1,13 @@
+{
+  "ips_scanned": 1,
+  "protocols": [
+     "TLS_1_2",
+     "TLS_1_1",
+     "TLS_1_0"
+  ],
+  "hsts_present": true,
+  "trusted": true,
+  "scan_results": {
+  },
+  "domain": "testapp.herokuapp.com"
+}

--- a/tests/examples/tls_scan_hsts.json
+++ b/tests/examples/tls_scan_hsts.json
@@ -8,5 +8,6 @@
    "hsts_present": true,
    "trusted": true,
    "scan_results": {
-   }
+   },
+   "domain": "example.com"
 }

--- a/tests/examples/tls_scan_valid.json
+++ b/tests/examples/tls_scan_valid.json
@@ -4,5 +4,6 @@
   "hsts_present": true,
   "trusted": true,
   "scan_results": {
-  }
+  },
+  "domain": "example.com"
 }

--- a/tests/test_tls_analyzer.py
+++ b/tests/test_tls_analyzer.py
@@ -15,9 +15,12 @@ def test_good_scan():
 
     res = analyzer.analyze()
 
-    assert res.req1.passed is True
-    assert res.req1.description == [NO_ISSUES]
-    assert res.req1.proof == []
+    assert res.req1_1.passed is True
+    assert res.req1_1.description == [NO_ISSUES]
+    assert res.req1_1.proof == []
+    assert res.req1_2.passed is True
+    assert res.req1_2.description == [NO_ISSUES]
+    assert res.req1_2.proof == []
     assert res.req3.passed is True
     assert res.req3.description == [NO_ISSUES]
     assert res.req3.proof == []
@@ -31,9 +34,12 @@ def test_hsts_valid():
 
     res = analyzer.analyze()
 
-    assert res.req1.passed is False
-    assert res.req1.description == [TLS_PROTOCOLS]
-    assert res.req1.proof == ['Protocols Found: [\'TLS_1_2\', \'TLS_1_1\', \'TLS_1_0\']']
+    assert res.req1_1.passed is False
+    assert res.req1_1.description == [TLS_PROTOCOLS]
+    assert res.req1_1.proof == ['Protocols Found: [\'TLS_1_2\', \'TLS_1_1\', \'TLS_1_0\']']
+    assert res.req1_2.passed is True
+    assert res.req1_2.description == [NO_ISSUES]
+    assert res.req1_2.proof == []
     assert res.req3.passed is True
     assert res.req3.description == [NO_ISSUES]
     assert res.req3.proof == []
@@ -47,12 +53,33 @@ def test_expired_cert():
 
     res = analyzer.analyze()
 
-    assert res.req1.passed is False
-    assert res.req1.description == [TLS_PROTOCOLS, HSTS_MISSING]
-    assert res.req1.proof == [
-        'Protocols Found: [\'TLS_1_2\', \'TLS_1_1\', \'TLS_1_0\']',
-        'We did not detect an HSTS header when scanning your app.'
-    ]
+    assert res.req1_1.passed is False
+    assert res.req1_1.description == [TLS_PROTOCOLS]
+    assert res.req1_1.proof == ['Protocols Found: [\'TLS_1_2\', \'TLS_1_1\', \'TLS_1_0\']']
+    assert res.req1_2.passed is False
+    assert res.req1_2.description == [HSTS_MISSING]
+    assert res.req1_2.proof == ['We did not detect an HSTS header when scanning your app.']
     assert res.req3.passed is False
     assert res.req3.description == [CERT_NOT_VALID]
     assert res.req3.proof == ['Your app presented an HTTPS certificate that was not valid.']
+
+
+def test_heroku_domain():
+    file = 'tests/examples/tls_scan_heroku.json'
+    scan = TlsResult(json.load(open(file, 'r')))
+    reqs = Requirements()
+    analyzer = TlsAnalyzer(scan, reqs)
+
+    res = analyzer.analyze()
+
+    assert res.req1_1.passed is True
+    assert res.req1_1.description == [NO_ISSUES]
+    assert res.req1_1.proof == [
+        'testapp.herokuapp.com is a Heroku domain and is not subject to TLS requirements until July 31, 2021'
+    ]
+    assert res.req1_2.passed is True
+    assert res.req1_2.description == [NO_ISSUES]
+    assert res.req1_2.proof == []
+    assert res.req3.passed is True
+    assert res.req3.description == [NO_ISSUES]
+    assert res.req3.proof == []


### PR DESCRIPTION
## Description of Change
* Heroku apps should no longer fail TLS checks
* Breakdown Requirement 1 into two separate requirements (TLS and HSTS)
* Update tests to support this change

## Fixes
Closes #21 

## Did you test your changes?
- [x] Yes

Updated TLS Analyzer tests and added one new test for a Heroku domain

## Reviewers
@anshumanbh 
