### PR TITLE
[AUT-185] Timeout failing app endpoints faster, better logging about timeouts

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import sys
+from datetime import datetime
 
 import fire
 
@@ -15,6 +16,7 @@ from utils.app_validator import AppValidator
 
 
 def main(descriptor_url, skip_branding=False, debug=False, out_dir='out'):
+    start = datetime.now()
     # Setup our logging
     setup_logging(debug)
     # Validate that the descriptor URL points to a seemingly valid connect app descriptor
@@ -58,6 +60,8 @@ def main(descriptor_url, skip_branding=False, debug=False, out_dir='out'):
     # Generate a report based on the analyzed results against Security Requirements
     generator = ReportGenerator(results, out_dir, skip_branding)
     generator.save_report()
+
+    logging.info(f"CSRT Scan completed in: {datetime.now() - start}")
 
     if results.errors:
         errors: str = '\n'.join(descriptor_res.link_errors)

--- a/utils/csrt_session.py
+++ b/utils/csrt_session.py
@@ -21,7 +21,7 @@ class TimeoutHTTPAdapter(HTTPAdapter):
         return super().send(request, **kwargs)
 
 
-def create_csrt_session(timeout: int = 90) -> requests.Session:
+def create_csrt_session(timeout: int = 60) -> requests.Session:
     """Return a requests.Session object setup in a standard way to make HTTP requests from
 
     Returns:


### PR DESCRIPTION
## Description of Change
* Timeout reduced to 60 seconds, from 90 seconds
* Catch timeout errors individually and report them as such
* Handle all other link errors cleaner
* Report CSRT runtime via logging

## Fixes
Internal fix, no public GH issues are being resolved

## Did you test your changes?
- [x] Yes

No new tests added

## Reviewers
@anshumanbh 
