### PR TITLE
[AUT-200] Add a timeout argument to CSRT

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This utility can be run as a python script or can be built as a Docker container
 
 Using CSRT with Python requires [pipenv](https://pipenv.pypa.io) to be installed.
 
-`pipenv run python main.py url-to-atlassian-connect-json --debug=True/False --out_dir=./out --skip_branding=True/False`
+`pipenv run python main.py url-to-atlassian-connect-json --debug=True/False --out_dir=./out --skip_branding=True/False --timeout=30`
 
 Example: `pipenv run python3 main.py https://example.com/atlassian-connect.json`
 
@@ -23,6 +23,7 @@ Example: `pipenv run python3 main.py https://example.com/atlassian-connect.json`
 ### Arguments
 | Argument | Argument Description |
 |----------|----------------------|
+|--timeout          | Defines how long CSRT will wait on web requests before timing out, **default: 30 seconds**        |
 |--skip_branding    | Whether or not to skip branding checks, **default: False**                                        |
 |--out_dir          | The output directory where results are stored, **default: ./out**                                 |
 |--debug            | Sets logging to DEBUG for more verbose logging, **default: False**                                |
@@ -41,8 +42,6 @@ To run the entire test suite:
 
 * `pipenv run lint` -- Runs flake8 with the project settings
 * `pipenv run test` -- Runs pytest with the project settings
-
-Tests may take a few minutes to run as we rely on the Qualys API to return results back to us to confirm functionality.
 
 ## Issues / Feedback?
 Found a bug or have an idea for an improvement? Create an issue via the [issue tracker](https://github.com/atlassian-labs/connect-security-req-tester/issues).

--- a/main.py
+++ b/main.py
@@ -15,18 +15,18 @@ from scans.tls_scan import TlsScan
 from utils.app_validator import AppValidator
 
 
-def main(descriptor_url, skip_branding=False, debug=False, out_dir='out'):
+def main(descriptor_url, skip_branding=False, debug=False, timeout=30, out_dir='out'):
     # Setup our logging
     setup_logging(debug)
     logging.info(f"CSRT Scan started at: {(start := datetime.now())}")
     # Validate that the descriptor URL points to a seemingly valid connect app descriptor
-    validator = AppValidator(descriptor_url)
+    validator = AppValidator(descriptor_url, timeout)
     validator.validate()
     descriptor = validator.get_descriptor()
 
     # Run our scans -- SSL/TLS and Descriptor Checks
     tls_scan = TlsScan(descriptor['baseUrl'])
-    descriptor_scan = DescriptorScan(descriptor_url, descriptor)
+    descriptor_scan = DescriptorScan(descriptor_url, descriptor, timeout)
 
     tls_res = tls_scan.scan()
     descriptor_res = descriptor_scan.scan()

--- a/scans/descriptor_scan.py
+++ b/scans/descriptor_scan.py
@@ -18,12 +18,12 @@ BRACES_MATCHER = r'\$?{.*}'
 
 
 class DescriptorScan(object):
-    def __init__(self, descriptor_url: str, descriptor: dict):
+    def __init__(self, descriptor_url: str, descriptor: dict, timeout: int):
         self.descriptor_url: str = descriptor_url
         self.descriptor: dict = descriptor
         self.base_url: str = descriptor['baseUrl'] if not descriptor['baseUrl'].endswith('/') else descriptor['baseUrl'][:-1]
         self.links = self._get_links()
-        self.session = create_csrt_session()
+        self.session = create_csrt_session(timeout)
         self.link_errors: list = []
 
     def _get_links(self) -> List[str]:

--- a/tests/test_app_validator.py
+++ b/tests/test_app_validator.py
@@ -20,7 +20,7 @@ def setup_module(module):
 def test_descriptor_fetch():
     url = f"https://connect-inspector.services.atlassian.com/resources/{ADDON_KEY}/atlassian-connect.json"
     actual_descriptor = requests.get(url).json()
-    validator = AppValidator(url)
+    validator = AppValidator(url, 30)
 
     assert validator.descriptor == actual_descriptor
     assert validator.descriptor_url == url
@@ -29,7 +29,7 @@ def test_descriptor_fetch():
 
 def test_valid_descriptor():
     url = f"https://connect-inspector.services.atlassian.com/resources/{ADDON_KEY}/atlassian-connect.json"
-    validator = AppValidator(url)
+    validator = AppValidator(url, 30)
 
     assert validator.validate() is True
 
@@ -40,6 +40,7 @@ def test_missing_keys():
     validator.session = None
     validator.descriptor_url = 'https://example.com'
     validator.descriptor = json.loads(open(descriptor_file, 'r').read())
+    validator.timeout = 30
 
     assert validator._validate_required_keys() is False
     with pytest.raises(SystemExit) as wrapped_e:
@@ -55,6 +56,7 @@ def test_invalid_base_url():
     validator.session = None
     validator.descriptor_url = 'https://example.com'
     validator.descriptor = json.loads(open(descriptor_file, 'r').read())
+    validator.timeout = 30
 
     assert validator._validate_base_url() is False
     with pytest.raises(SystemExit) as wrapped_e:
@@ -72,7 +74,7 @@ def test_invalid_remote_descriptors():
     ]
 
     for url in urls:
-        validator = AppValidator(url)
+        validator = AppValidator(url, 30)
 
         with pytest.raises(SystemExit) as wrapped_e:
             validator.validate()

--- a/tests/test_descriptor_scan.py
+++ b/tests/test_descriptor_scan.py
@@ -43,7 +43,7 @@ def create_scan_results(links):
 def test_init_valid_url():
     valid_url = f"https://connect-inspector.services.atlassian.com/resources/{ADDON_KEY}/atlassian-connect.json"
     descriptor = requests.get(valid_url).json()
-    scanner = DescriptorScan(valid_url, descriptor)
+    scanner = DescriptorScan(valid_url, descriptor, 30)
     links = get_links_from_descriptor(descriptor)
 
     assert scanner.descriptor_url == valid_url
@@ -55,7 +55,7 @@ def test_init_valid_url():
 def test_scan_valid_app():
     valid_url = f"https://connect-inspector.services.atlassian.com/resources/{ADDON_KEY}/atlassian-connect.json"
     descriptor = requests.get(valid_url).json()
-    scanner = DescriptorScan(valid_url, descriptor)
+    scanner = DescriptorScan(valid_url, descriptor, 30)
     res = scanner.scan().to_json()
     res['links'].sort()
     res = json.dumps(res, sort_keys=True)

--- a/utils/app_validator.py
+++ b/utils/app_validator.py
@@ -10,8 +10,8 @@ REQUIRED_KEYS = ['baseUrl', 'key', 'name']
 
 
 class AppValidator(object):
-    def __init__(self, descriptor_url: str):
-        self.session = create_csrt_session()
+    def __init__(self, descriptor_url: str, timeout: int):
+        self.session = create_csrt_session(timeout)
         self.descriptor_url = descriptor_url
         self.descriptor = self._get_and_request_descriptor()
 

--- a/utils/csrt_session.py
+++ b/utils/csrt_session.py
@@ -21,7 +21,7 @@ class TimeoutHTTPAdapter(HTTPAdapter):
         return super().send(request, **kwargs)
 
 
-def create_csrt_session(timeout: int = 60) -> requests.Session:
+def create_csrt_session(timeout: int = 30) -> requests.Session:
     """Return a requests.Session object setup in a standard way to make HTTP requests from
 
     Returns:


### PR DESCRIPTION
## Description of Change
* Added a new CLI argument to CSRT that allows you to dynamically define the scanner's HTTP timeout
* Updated tests to reflect this change
* Updated README to reflect this change

## Fixes
* Internal feature request, no public GH issues

## Did you test your changes?
- [x] Yes

Updated tests to account for the new `timeout` argument being passed around

## Reviewers
@anshumanbh 
