### PR TITLE
[AUT-222] Branding checks should ignore subdomains

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: File a big report for CSRT
+about: File a bug report for CSRT
 title: ''
 labels: bug
 assignees: ''

--- a/analyzers/branding_analyzer.py
+++ b/analyzers/branding_analyzer.py
@@ -43,10 +43,9 @@ class BrandingAnalyzer(object):
         proof: List[str] = []
         for link in self.links:
             sub, domain, suffix = tldextract.extract(link)
-            sub_test = self._check_against_denylist(sub, DOMAIN_DENYLIST)
             domain_test = self._check_against_denylist(domain, DOMAIN_DENYLIST)
 
-            if sub_test or domain_test:
+            if domain_test:
                 proof.append(
                     f"{link} | Contains a denied word in the subdomain or primary domain"
                 )

--- a/tests/test_branding_analyzer.py
+++ b/tests/test_branding_analyzer.py
@@ -71,3 +71,17 @@ def test_good_app():
     assert res.req16.description == [NO_ISSUES]
     assert res.req16.title == REQ_TITLES['16']
     assert res.req16.proof == []
+
+
+def test_subdomain_exclusion():
+    links = ['https://atlassian.myapp.com/confluence']
+    name = 'Example App'
+    reqs = Requirements()
+    analyzer = BrandingAnalyzer(links, name, reqs)
+
+    res = analyzer.analyze()
+
+    assert res.req16.passed is True
+    assert res.req16.description == [NO_ISSUES]
+    assert res.req16.title == REQ_TITLES['16']
+    assert res.req16.proof == []


### PR DESCRIPTION
## Description of Change
* Branding Analyzer now ignores subdomains
* Fixed a small typo in the bug template

## Fixes
Fixes #40

## Did you test your changes?
- [x] Yes

Added an additional test for subdomains in the branding analyzer

## Reviewers
@anshumanbh @mmission1 