### PR TITLE
Follow redirects when checking for HSTS

### DIFF
--- a/analyzers/hsts_analyzer.py
+++ b/analyzers/hsts_analyzer.py
@@ -14,7 +14,7 @@ class HstsAnalyzer(object):
 
         if not self.scan.header:
             passed = False
-            proof += ['We did not detect an HSTS header when scanning your app.']
+            proof += ['We did not detect an HSTS header when scanning your app\'s baseUrl.']
 
         return passed, proof
 

--- a/tests/test_hsts_analyzer.py
+++ b/tests/test_hsts_analyzer.py
@@ -31,6 +31,6 @@ def test_invalid_scan_header():
     assert res.req1_2.passed is False
     assert res.req1_2.description == [HSTS_MISSING]
     assert res.req1_2.proof == [
-        'We did not detect an HSTS header when scanning your app.'
+        'We did not detect an HSTS header when scanning your app\'s baseUrl.'
     ]
     assert res.req1_2.title == REQ_TITLES['1.2']


### PR DESCRIPTION
## Description of Change
* When checking for HSTS, we should follow any redirects that the `baseUrl` returns -- This gives folks the best possible chance to pass this check.
* Adjusted the `proof` text to better describe what failed and why

## Fixes
Internal bugfix

## Did you test your changes?
- [x] Yes

Updated test to reflect new HSTS proof wording

## Reviewers
@anshumanbh @mmission1 
