### PR TITLE
Handle remote descriptors, cleanup heroku exemption

### DIFF
--- a/analyzers/hsts_analyzer.py
+++ b/analyzers/hsts_analyzer.py
@@ -14,7 +14,7 @@ class HstsAnalyzer(object):
 
         if not self.scan.header:
             passed = False
-            proof += ['We did not detect an HSTS header when scanning your app\'s baseUrl.']
+            proof += [f"We did not detect a Strict-Transport-Security (HSTS) header when scanning: {self.scan.scanned}"]
 
         return passed, proof
 

--- a/analyzers/tls_analyzer.py
+++ b/analyzers/tls_analyzer.py
@@ -1,13 +1,11 @@
 from typing import List, Tuple
 
-import dns.resolver
 from models.requirements import Requirements, RequirementsResult
 from models.tls_result import TlsResult
 from reports.constants import (CERT_NOT_VALID, NO_ISSUES, REQ_TITLES,
                                TLS_PROTOCOLS)
 
 PROTO_DENYLIST = ['TLS_1_0', 'TLS_1_1', 'SSL_3_0', 'SSL_2_0']
-HEROKU_DOMAINS = ['herokuapp.com', 'herokudns.com']
 
 
 class TlsAnalyzer(object):
@@ -15,37 +13,14 @@ class TlsAnalyzer(object):
         self.scan: TlsResult = tls_scan
         self.reqs: Requirements = requirements
 
-    def _check_for_heroku(self) -> bool:
-        # Quick check to see if the base_url is a heroku domain
-        if any(domain in self.scan.domain for domain in HEROKU_DOMAINS):
-            return True
-
-        # Look for CNAME entries for the base_url that point to a Heroku asset
-        # If an exception is thrown, it is due to the fact that no CNAME results were returned
-        try:
-            res = dns.resolver.resolve(self.scan.domain, 'CNAME')
-        except dns.exception.DNSException:
-            return False
-        else:
-            for r in res:
-                if any(domain in str(r.target) for domain in HEROKU_DOMAINS):
-                    return True
-
-        return False
-
     def _check_tls_versions(self) -> Tuple[bool, List[str]]:
         passed = True
         proof: List[str] = []
-        is_heroku = self._check_for_heroku()
 
-        uses_bad_protos = not is_heroku and any(item in self.scan.protocols for item in PROTO_DENYLIST)
+        uses_bad_protos = any(item in self.scan.protocols for item in PROTO_DENYLIST)
         if uses_bad_protos:
-            proof += [f"Protocols Found: {self.scan.protocols}"]
+            proof += [f"Your domain: {self.scan.domain} - presented the following protocols: {self.scan.protocols}"]
             passed = False
-
-        # Heroku auto-pass check
-        if is_heroku:
-            proof += [f"{self.scan.domain} is a Heroku domain and is not subject to TLS requirements until July 31, 2021"]
 
         return passed, proof
 
@@ -54,7 +29,7 @@ class TlsAnalyzer(object):
         proof: List[str] = []
 
         if not passed:
-            proof += ['Your app presented an HTTPS certificate that was not valid.']
+            proof += [f"Your domain: {self.scan.domain} - presented an HTTPS certificate that was not valid."]
 
         return passed, proof
 

--- a/models/hsts_result.py
+++ b/models/hsts_result.py
@@ -3,3 +3,4 @@ from jsonobject import JsonObject, StringProperty
 
 class HstsResult(JsonObject):
     header = StringProperty()
+    scanned = StringProperty()

--- a/reports/failures.py
+++ b/reports/failures.py
@@ -50,11 +50,12 @@ class FailureGenerator(object):
         if "timeouts" in self.results.errors:
             Path(self.out_dir + '/' + timeout_fname).mkdir(exist_ok=True, parents=True)
             json_name = f"{timeout_fname}/{self.results.key}.json"
+            self._write_output(json.dumps([json_report.to_json()]), json_name)
         if "service_unavailable" in self.results.errors:
             Path(self.out_dir + '/' + service_unavailable_fname).mkdir(exist_ok=True, parents=True)
             json_name = f"{service_unavailable_fname}/{self.results.key}.json"
+            self._write_output(json.dumps([json_report.to_json()]), json_name)
         if "infinite_redirects" in self.results.errors:
             Path(self.out_dir + '/' + infinite_redirects_fname).mkdir(exist_ok=True, parents=True)
             json_name = f"{infinite_redirects_fname}/{self.results.key}.json"
-
-        self._write_output(json.dumps([json_report.to_json()]), json_name)
+            self._write_output(json.dumps([json_report.to_json()]), json_name)

--- a/scans/hsts_scan.py
+++ b/scans/hsts_scan.py
@@ -6,27 +6,28 @@ from utils.csrt_session import create_csrt_session
 
 
 class HstsScan(object):
-    def __init__(self, base_url: str, timeout: int):
-        self.base_url = base_url
+    def __init__(self, check_url: str, timeout: int):
+        self.check_url = check_url
         self.session = create_csrt_session(timeout)
 
     def _check_for_hsts(self) -> Optional[str]:
         try:
-            res = self.session.get(self.base_url)
+            res = self.session.get(self.check_url)
             # Docs: https://docs.python-requests.org/en/master/user/quickstart/#response-headers
             # Requests "headers" dictionary are special and case-insensitive
             hsts_header = res.headers.get('strict-transport-security', None)
             return hsts_header
         except Exception as e:
-            logging.error(f"HSTS Scan failed to scan {self.base_url} due to: {e}")
+            logging.error(f"HSTS Scan failed to scan {self.check_url} due to: {e}")
             return None
 
     def scan(self) -> HstsResult:
-        logging.info(f"Checking {self.base_url} for an HSTS header...")
+        logging.info(f"Checking {self.check_url} for an HSTS header...")
         header = self._check_for_hsts()
 
         hsts_res = HstsResult(
-            header=header
+            header=header,
+            scanned=self.check_url
         )
 
         logging.info('HSTS check completed.')

--- a/tests/examples/hsts_invalid_header.json
+++ b/tests/examples/hsts_invalid_header.json
@@ -1,3 +1,4 @@
 {
-    "header": ""
+    "header": "",
+    "scanned": "https://example.com/atlassian-connect.json"
 }

--- a/tests/test_hsts_analyzer.py
+++ b/tests/test_hsts_analyzer.py
@@ -31,6 +31,6 @@ def test_invalid_scan_header():
     assert res.req1_2.passed is False
     assert res.req1_2.description == [HSTS_MISSING]
     assert res.req1_2.proof == [
-        'We did not detect an HSTS header when scanning your app\'s baseUrl.'
+        'We did not detect a Strict-Transport-Security (HSTS) header when scanning: https://example.com/atlassian-connect.json'
     ]
     assert res.req1_2.title == REQ_TITLES['1.2']

--- a/tests/test_hsts_scan.py
+++ b/tests/test_hsts_scan.py
@@ -5,7 +5,7 @@ def test_init_domain_valid():
     base_url = 'https://atlassian.com/connect-app'
     scanner = HstsScan(base_url, 5)
 
-    assert scanner.base_url == base_url
+    assert scanner.check_url == base_url
 
 
 def test_hsts_header_valid():

--- a/tests/test_tls_analyzer.py
+++ b/tests/test_tls_analyzer.py
@@ -32,25 +32,7 @@ def test_expired_cert():
 
     assert res.req1_1.passed is False
     assert res.req1_1.description == [TLS_PROTOCOLS]
-    assert res.req1_1.proof == ['Protocols Found: [\'TLS_1_2\', \'TLS_1_1\', \'TLS_1_0\']']
+    assert res.req1_1.proof == ['Your domain: example.com - presented the following protocols: [\'TLS_1_2\', \'TLS_1_1\', \'TLS_1_0\']']
     assert res.req3.passed is False
     assert res.req3.description == [CERT_NOT_VALID]
-    assert res.req3.proof == ['Your app presented an HTTPS certificate that was not valid.']
-
-
-def test_heroku_domain():
-    file = 'tests/examples/tls_scan_heroku.json'
-    scan = TlsResult(json.load(open(file, 'r')))
-    reqs = Requirements()
-    analyzer = TlsAnalyzer(scan, reqs)
-
-    res = analyzer.analyze()
-
-    assert res.req1_1.passed is True
-    assert res.req1_1.description == [NO_ISSUES]
-    assert res.req1_1.proof == [
-        'testapp.herokuapp.com is a Heroku domain and is not subject to TLS requirements until July 31, 2021'
-    ]
-    assert res.req3.passed is True
-    assert res.req3.description == [NO_ISSUES]
-    assert res.req3.proof == []
+    assert res.req3.proof == ['Your domain: example.com - presented an HTTPS certificate that was not valid.']


### PR DESCRIPTION
## Description of Change
* Add support for handling the difference between scanning a Marketplace cached descriptor versus a remote descriptor
* Remove Heroku exemption since it is past July 31, 2021
* Make proof messages more descriptive and useful
* Fix a minor bug in writing scan failures to file -- It only wrote one file instead of anything that matches
* Update tests

## Fixes
N/A -- Internal bugfix

## Did you test your changes?
- [x] Yes

Updated tests to reflect new changes

## Reviewers
@mmission1 @jwong33 
