### PR TITLE
Raise an exception when the HSTS scan fails

### DIFF
--- a/scans/hsts_scan.py
+++ b/scans/hsts_scan.py
@@ -19,7 +19,7 @@ class HstsScan(object):
             return hsts_header
         except Exception as e:
             logging.error(f"HSTS Scan failed to scan {self.check_url} due to: {e}")
-            return None
+            raise e
 
     def scan(self) -> HstsResult:
         logging.info(f"Checking {self.check_url} for an HSTS header...")

--- a/tests/test_hsts_scan.py
+++ b/tests/test_hsts_scan.py
@@ -1,4 +1,6 @@
 from scans.hsts_scan import HstsScan
+import pytest
+import requests
 
 
 def test_init_domain_valid():
@@ -38,3 +40,13 @@ def test_hsts_invalid():
     res = scanner.scan()
 
     assert res.header is None
+
+
+def test_hsts_timeout():
+    base_url = 'https://httpstat.us/200?sleep=50000'
+    scanner = HstsScan(base_url, 5)
+
+    with pytest.raises(requests.exceptions.ReadTimeout) as wrapped_e:
+        scanner.scan()
+
+    assert wrapped_e.type == requests.exceptions.ReadTimeout


### PR DESCRIPTION
## Description of Change
* Raise an exception when the HSTS check encounters an exception -- essentially force CSRT to fail when this scan fails

## Fixes
* Internal bugfix

## Did you test your changes?
- [x] Yes

Added new test for the HSTS scan exception

## Reviewers
@mmission1 @jwong33 
