### PR TITLE
TLS Scan fixes

### DIFF
--- a/scans/tls_scan.py
+++ b/scans/tls_scan.py
@@ -53,7 +53,7 @@ class TlsScan(object):
                 *self.CIPHER_SUITES
             }
         )
-        scanner.queue_scan(scan_request)
+        scanner.start_scans([scan_request])
         res = scanner.get_results()
         # Unpack the generator that is returned as we need to navigate this
         # data structure multiple times
@@ -87,9 +87,10 @@ class TlsScan(object):
                         protocols.add(result.tls_version_used.name)
                 except KeyError:
                     # there was an error trying to get that cipher suite or we did not send the corresponding command
-                    # TODO log the scan command errors
                     pass
-
+            # log the scan errors
+            for scan_cmd, err in res.scan_commands_errors.items():
+                logging.error(f"Error when running {scan_cmd}:\n{err.exception_trace}\n")
         return list(protocols)
 
     def scan(self) -> TlsResult:


### PR DESCRIPTION
## Description of Change
The sslyze library doesn't add the cipher suite scans to scan_commands_results if the client does not have a certificate, which causes our program to crash. Error handling was added to the code that accesses scan_command_results and tls_scan now logs any scan_command_errors we encountered. Furthermore, queue_scans was replaced with a call to start_scans, since queue_scans is currently [deprecated](https://github.com/nabla-c0d3/sslyze/blob/02ede714d52ba11912d64f95daafef9e386587d1/sslyze/scanner/scanner.py) in sslyze. 

## Did you test your changes?
- [x] Yes

Include any notes for tests added or issues encountered.

## Reviewers
@seanmarpo 
@mmission1 
