### PR TITLE
Fixed cert chains with anchors causing incorrect result

### DIFF
--- a/scans/tls_scan.py
+++ b/scans/tls_scan.py
@@ -67,11 +67,10 @@ class TlsScan(object):
         for res in scan_res:
             cert_info = res.scan_commands_results[ScanCommand.CERTIFICATE_INFO]
             for dep in cert_info.certificate_deployments:
+                if dep.verified_certificate_chain is None:
+                    return False
                 if not dep.leaf_certificate_subject_matches_hostname:
                     return False
-                for validation in dep.path_validation_results:
-                    if not validation.verified_certificate_chain:
-                        return False
 
         return True
 


### PR DESCRIPTION
## Description of Change
* Certificates that contain an anchor were being incorrectly marked as invalid

## Fixes
Internal bugfix

## Did you test your changes?
- [x] Yes

Could not find a domain that incorrectly includes an anchor without exposing the connect app that does this behavior. This was tested internally and does resolve the issue.

## Reviewers
@anshumanbh @jwong33 
